### PR TITLE
Fix /config endpoint not including a version when not started via npm…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-tfa-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "author": "",
   "license": "UNLICENSED",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -5,7 +5,17 @@ import * as config from 'config';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService, private readonly notificationService: NotificationService) {}
+  private readonly version: string;
+
+  constructor(private readonly appService: AppService, private readonly notificationService: NotificationService) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      this.version = require('./package.json').version;
+    } catch {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      this.version = require('../package.json').version;
+    }
+  }
 
   @Get('healthcheck')
   @Header('Cache-Control', 'public, max-age=15')
@@ -66,7 +76,7 @@ export class AppController {
   public getConfig() {
     return {
       success: true,
-      version: process.env.npm_package_version,
+      version: this.version,
       push: {
         supported: config.get<boolean>('PushNotifications.Enabled'),
         apiKey: config.get<string>('PushNotifications.ApiKey'),


### PR DESCRIPTION
… (e.g. in the docker container)

closes #9